### PR TITLE
Remove unused header from libcrippy.c

### DIFF
--- a/src/libcrippy.c
+++ b/src/libcrippy.c
@@ -20,7 +20,6 @@
 #include <libcrippy-1.0/boolean.h>
 #include <libcrippy-1.0/libcrippy.h>
 
-#include <libimobiledevice/libimobiledevice.h>
 #include <plist/plist.h>
 //#define PRINT_VERBOSE(min_level, ...) if (verbose >= min_level) { printf(__VA_ARGS__); };
 #define PRINT_VERBOSE(min_level, ...) if (10 >= min_level) { printf(__VA_ARGS__); };


### PR DESCRIPTION
This allows to compile without having libimobiledevice installed.